### PR TITLE
Session 3: Introduce Practices Section and Demonstration Components for Material-UI Testing

### DIFF
--- a/recipe-sharing-app/src/App.jsx
+++ b/recipe-sharing-app/src/App.jsx
@@ -1,14 +1,12 @@
 import React from 'react'
-import Greeting from './components/Greeting'
-import Counter from './components/Counter'
+import Practices from './practices/Practices'
+// import Greeting from './components/Greeting'
+// import Counter from './components/Counter'
 
 function App() {
 
   return (
-    <div>
-      <Greeting name="Student" />
-      <Counter />
-    </div>
+    <Practices />
   )
 }
 

--- a/recipe-sharing-app/src/practices/BoxDemo.jsx
+++ b/recipe-sharing-app/src/practices/BoxDemo.jsx
@@ -1,9 +1,12 @@
 import React from 'react'
+import { Box } from '@mui/material'
 
 function BoxDemo() {
   return (
     <div>
-
+        <Box sx={{ padding: '20px', backgroundColor: 'lightblue', textAlign: 'center' }}>
+            This is a styled box
+        </Box>
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/BoxDemo.jsx
+++ b/recipe-sharing-app/src/practices/BoxDemo.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+function BoxDemo() {
+  return (
+    <div>
+
+    </div>
+  )
+}
+
+export default BoxDemo

--- a/recipe-sharing-app/src/practices/ButtonDemo.jsx
+++ b/recipe-sharing-app/src/practices/ButtonDemo.jsx
@@ -6,7 +6,7 @@ function ButtonDemo() {
     <div>
         <Button variant='contained' color='primary'>Primary</Button>
         <Button variant='outlined' color='secondary'>Secondary</Button>
-
+        <Button variant='text' color='success'>Success</Button>
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/ButtonDemo.jsx
+++ b/recipe-sharing-app/src/practices/ButtonDemo.jsx
@@ -1,8 +1,10 @@
+import { Button } from '@mui/material'
 import React from 'react'
 
 function ButtonDemo() {
   return (
     <div>
+        <Button variant='contained' color='primary'>Primary</Button>
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/ButtonDemo.jsx
+++ b/recipe-sharing-app/src/practices/ButtonDemo.jsx
@@ -5,6 +5,8 @@ function ButtonDemo() {
   return (
     <div>
         <Button variant='contained' color='primary'>Primary</Button>
+        <Button variant='outlined' color='secondary'>Secondary</Button>
+
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/ButtonDemo.jsx
+++ b/recipe-sharing-app/src/practices/ButtonDemo.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+function ButtonDemo() {
+  return (
+    <div>
+    </div>
+  )
+}
+
+export default ButtonDemo

--- a/recipe-sharing-app/src/practices/GridDemo.jsx
+++ b/recipe-sharing-app/src/practices/GridDemo.jsx
@@ -12,7 +12,9 @@ function GridDemo() {
           </Box>
         </Grid>
         <Grid item xs={6}>
-          <Box sx={{ backgroundColor: 'lightblue', height: '100px' }} />
+          <Box sx={{ backgroundColor: 'lightgreen', padding: '20px' }} >
+            Column 2
+          </Box>
         </Grid>
       </Grid>
     </div>

--- a/recipe-sharing-app/src/practices/GridDemo.jsx
+++ b/recipe-sharing-app/src/practices/GridDemo.jsx
@@ -5,7 +5,16 @@ import Box from '@mui/material/Box'
 function GridDemo() {
   return (
     <div>
-
+      <Grid container spacing={2}>
+        <Grid item xs={6}>
+          <Box sx={{ backgroundColor: 'lightcoral', padding: '20px' }} >
+            Column 1
+          </Box>
+        </Grid>
+        <Grid item xs={6}>
+          <Box sx={{ backgroundColor: 'lightblue', height: '100px' }} />
+        </Grid>
+      </Grid>
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/GridDemo.jsx
+++ b/recipe-sharing-app/src/practices/GridDemo.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Grid } from '@mui/material'
+import Box from '@mui/material/Box'
+
+function GridDemo() {
+  return (
+    <div>
+
+    </div>
+  )
+}
+
+export default GridDemo

--- a/recipe-sharing-app/src/practices/Practices.jsx
+++ b/recipe-sharing-app/src/practices/Practices.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
+import ButtonDemo from './ButtonDemo'
 
 function Practices() {
   return (
     <div>
       <h1>Testing MUI components</h1>
+      <ButtonDemo />
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/Practices.jsx
+++ b/recipe-sharing-app/src/practices/Practices.jsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import ButtonDemo from './ButtonDemo'
+import BoxDemo from './BoxDemo'
 
 function Practices() {
   return (
     <div>
       <h1>Testing MUI components</h1>
       <ButtonDemo />
+      <BoxDemo />
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/Practices.jsx
+++ b/recipe-sharing-app/src/practices/Practices.jsx
@@ -2,7 +2,9 @@ import React from 'react'
 
 function Practices() {
   return (
-    <div>Practices</div>
+    <div>
+      <h1>Testing MUI components</h1>
+    </div>
   )
 }
 

--- a/recipe-sharing-app/src/practices/Practices.jsx
+++ b/recipe-sharing-app/src/practices/Practices.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ButtonDemo from './ButtonDemo'
 import BoxDemo from './BoxDemo'
+import GridDemo from './GridDemo'
 
 function Practices() {
   return (
@@ -8,6 +9,7 @@ function Practices() {
       <h1>Testing MUI components</h1>
       <ButtonDemo />
       <BoxDemo />
+      <GridDemo />
     </div>
   )
 }

--- a/recipe-sharing-app/src/practices/Practices.jsx
+++ b/recipe-sharing-app/src/practices/Practices.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+function Practices() {
+  return (
+    <div>Practices</div>
+  )
+}
+
+export default Practices


### PR DESCRIPTION
### Summary of Changes
- 🛠️ **Add Practices Section**: Introduced a new `Practices` component as a dedicated area for Material-UI component demonstrations.
- 🔘 **Create ButtonDemo Component**: Added the `ButtonDemo` component showcasing various button variants, including primary, secondary, and success styles.
- 🟦 **Create BoxDemo Component**: Developed the `BoxDemo` component with styled Material-UI `Box` for enhanced layout presentation.
- 📐 **Create GridDemo Component**: Implemented the `GridDemo` component to demonstrate grid layouts and structure using Material-UI's grid system.
- 🚀 **Integrate Components into Practices**: Added `ButtonDemo`, `BoxDemo`, and `GridDemo` to the `Practices` component for organized Material-UI testing.
